### PR TITLE
Aqua tests added

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,6 @@ BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Infiltrator = "5903a43b-9cc3-4c30-8d17-598619ec4e9b"
-JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
@@ -25,9 +24,16 @@ Reexport = "1"
 Revise = "3"
 Sleipnir = "0.12.6"
 julia = "1.10"
+Aqua = "0.8"
+Test = "1.10"
+Dates = "1.10"
+Distributed = "1.10"
+Pkg = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Aqua", "JET"]

--- a/test/Aqua.jl
+++ b/test/Aqua.jl
@@ -1,0 +1,10 @@
+function test_Aqua()
+    Aqua.test_ambiguities(Muninn)
+    Aqua.test_undefined_exports(Muninn)
+    Aqua.test_project_extras(Muninn)
+    Aqua.test_stale_deps(Muninn; ignore = [:JET, :Test, :BenchmarkTools, :Revise])
+    Aqua.test_deps_compat(Muninn)
+    Aqua.test_piracies(Muninn)
+    Aqua.test_persistent_tasks(Muninn)
+    Aqua.test_undocumented_names(Muninn; broken = true)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,9 +11,11 @@ using JLD2
 using Infiltrator
 using Dates
 using JET
+using Aqua
 
 include("TI.jl")
 include("MB.jl")
+include("Aqua.jl")
 
 # Activate to avoid GKS backend Plot issues in the JupyterHub
 ENV["GKSwstype"]="nul"
@@ -22,4 +24,5 @@ ENV["GKSwstype"]="nul"
     @testset "Construct TI models by default" TI_creation_default_test()
     @testset "Construct TI models with input values" TI_creation_values_test()
     @testset "Apply MB model" apply_MB_test()
+    @testset "Aqua" test_Aqua()
 end


### PR DESCRIPTION
Adding Aqua tests to the test suite. So far, I've added all of them except for:

- [Method ambiguities](https://juliatesting.github.io/Aqua.jl/stable/ambiguities/), which has conflicts with the use of `Union{F, Nothing}`.
- [Undocumented names](https://juliatesting.github.io/Aqua.jl/stable/undocumented_names/), which enforces documenting absolutely everything. For now it's set to `broken=true`.

Addresses https://github.com/ODINN-SciML/ODINN.jl/issues/387