### PR TITLE
Rename calibrate_MB_model! to calibrate_MB_model

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Muninn"
 uuid = "4b816528-16ba-4e32-9a2e-3c1bc2049d3a"
-version = "0.12.1"
+version = "0.13.0"
 authors = ["Jordi Bolibar <jordi.bolibar@gmail.com>"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,7 @@ Pkg = "1.10, 1.11"
 Reexport = "1"
 Roots = "2"
 Revise = "3"
-Sleipnir = "0.15.1"
+Sleipnir = "0.16"
 Test = "1.10, 1.11"
 julia = "1.10, 1.11"
 

--- a/examples/calibrate_ti_hugonnet.jl
+++ b/examples/calibrate_ti_hugonnet.jl
@@ -52,9 +52,9 @@ const WGMS_GLACIERS = [
 const CALIBRATION_TSPAN = (2000.0, 2020.0)
 
 # Standalone Muninn runs single-process (multiprocessing is handled by Huginn/ODINN).
-# At scale (hundreds/thousands of glaciers), use calibrate_MB_model! via a
+# At scale (hundreds/thousands of glaciers), use calibrate_MB_model via a
 # Huginn Prediction or ODINN Inversion — their Parameters constructor loads Muninn
-# on the workers so the pmap in calibrate_MB_model! distributes automatically.
+# on the workers so the pmap in calibrate_MB_model distributes automatically.
 params = Sleipnir.Parameters(
     simulation = Sleipnir.SimulationParameters(
     tspan = CALIBRATION_TSPAN,
@@ -104,16 +104,16 @@ end
 #
 # It returns a fresh TImodel1 with calibrated (DDF, prcp_fac, temp_bias).
 # To calibrate the MB model of a whole simulation, use
-# calibrate_MB_model!(model, glaciers, params) instead (or just set
+# calibrate_MB_model(model, glaciers, params) instead (or just set
 # `calibrate_MB = true` in SimulationParameters).
 
 # TI1 calibration uses static glacier geometry, so no iceflow model is needed
 # (the Model.iceflow field is never read during calibration).
-# calibrate_MB_model! expands the single TImodel1 template into a per-glacier
+# calibrate_MB_model expands the single TImodel1 template into a per-glacier
 # vector of calibrated models, running the fits under pmap — distributed across
 # workers when multiprocessing = true.
 model = Model(; iceflow = nothing, mass_balance = TImodel1(params))
-calibrate_MB_model!(model, glaciers, params)
+model = calibrate_MB_model(model, glaciers, params)
 calibrated_models = model.mass_balance
 
 # ============================================================================

--- a/src/models/mass_balance/calibration.jl
+++ b/src/models/mass_balance/calibration.jl
@@ -282,7 +282,7 @@ end
     ) -> Sleipnir.Model
 
 High-level entry point that calibrates the mass balance model of `model`
-per glacier against geodetic observations, returning a (possibly new) `model`.
+per glacier against geodetic observations, returning a new `model`.
 
 Calibration cannot happen in place: for `TImodel1` it replaces a single model by one
 model per glacier, which changes the type of the `mass_balance` field. Callers must use

--- a/src/models/mass_balance/calibration.jl
+++ b/src/models/mass_balance/calibration.jl
@@ -1,5 +1,5 @@
 
-export calibrate_MB_model!, calibrate_ti_model, compute_mean_annual_MB,
+export calibrate_MB_model, calibrate_ti_model, compute_mean_annual_MB,
        compute_cumulative_MB
 
 ###############################################
@@ -146,7 +146,7 @@ A static glacier geometry is assumed throughout (no ice-flow dynamics).
 
   - A `TImodel1{Sleipnir.Float}` with calibrated `DDF`, `prcp_fac`, and `temp_bias`.
 
-This is the per-glacier building block used by [`calibrate_MB_model!`](@ref) to
+This is the per-glacier building block used by [`calibrate_MB_model`](@ref) to
 build a per-glacier vector of calibrated models.
 
 # References
@@ -275,7 +275,7 @@ function calibrate_ti_model(
 end
 
 """
-    calibrate_MB_model!(
+    calibrate_MB_model(
         model::Sleipnir.Model,
         glaciers::Vector{<:AbstractGlacier},
         params::Parameters,
@@ -283,6 +283,10 @@ end
 
 High-level entry point that calibrates the mass balance model of `model`
 per glacier against geodetic observations, returning a (possibly new) `model`.
+
+Calibration cannot happen in place: for `TImodel1` it replaces a single model by one
+model per glacier, which changes the type of the `mass_balance` field. Callers must use
+the return value; discarding it silently keeps the uncalibrated model.
 
 The behaviour dispatches on the mass balance model type:
 
@@ -292,7 +296,7 @@ The behaviour dispatches on the mass balance model type:
     (uncalibrated) model and a warning is emitted.  If no glacier carries geodetic
     data, the model is returned unchanged.
   - any other [`MBmodel`](@ref): no-op — no calibration routine is defined, so the
-    model is returned untouched.  Add a `_calibrate_MB_model!(model, ::YourType, …)`
+    model is returned untouched.  Add a `_calibrate_MB_model(model, ::YourType, …)`
     method to support a new model type.
 
 An already-vectorized (per-glacier) mass balance model is left unchanged.  Any
@@ -301,7 +305,7 @@ keyword arguments are forwarded to the type-specific calibrator (e.g.
 `Prediction` and `Inversion` constructors call when
 `params.simulation.calibrate_MB` is `true`.
 """
-function calibrate_MB_model!(
+function calibrate_MB_model(
         model::Sleipnir.Model,
         glaciers::Vector{<:AbstractGlacier},
         params::Parameters;
@@ -309,11 +313,11 @@ function calibrate_MB_model!(
     # Nothing to do for empty or already per-glacier mass balance models.
     isnothing(model.mass_balance) && return model
     model.mass_balance isa AbstractVector && return model
-    return _calibrate_MB_model!(model, model.mass_balance, glaciers, params; kwargs...)
+    return _calibrate_MB_model(model, model.mass_balance, glaciers, params; kwargs...)
 end
 
 # Default: mass balance models without a calibration routine are left untouched.
-function _calibrate_MB_model!(
+function _calibrate_MB_model(
         model, ::MBmodel, ::Vector{<:AbstractGlacier}, ::Parameters; kwargs...)
     return model
 end
@@ -323,7 +327,7 @@ end
 # concrete type parameter. The `glacier::G` typeassert inside the closure
 # narrows pmap's Channel{Any} element to G, keeping calibrate_ti_model
 # dispatch and _brent fully type-stable for JET.
-function _calibrate_MB_model!(
+function _calibrate_MB_model(
         model, template::TImodel1,
         glaciers::Vector{G}, params::Parameters;
         kwargs...) where {G <: AbstractGlacier}
@@ -332,7 +336,7 @@ function _calibrate_MB_model!(
     results = pmap(glaciers) do glacier_any
         glacier = glacier_any::G
         if isnothing(glacier.dhdtData)
-            @warn "calibrate_MB_model!: skipping glacier $(glacier.rgi_id) " *
+            @warn "calibrate_MB_model: skipping glacier $(glacier.rgi_id) " *
                   "because dhdtData is nothing."
             return template
         end

--- a/test/calibration.jl
+++ b/test/calibration.jl
@@ -74,13 +74,13 @@ function calibrate_ti_model_test()
     @test isfinite(mb_cal)
     @test abs(mb_cal - geodetic_mb) < 1e-4  # within 0.1 mm w.e. yr⁻¹
 
-    # --- calibrate_MB_model!: high-level entry point expands to a per-glacier vector
+    # --- calibrate_MB_model: high-level entry point expands to a per-glacier vector
     model = Sleipnir.Model(; iceflow = nothing, mass_balance = TImodel1(params))
-    model = calibrate_MB_model!(model, [glacier], params)
+    model = calibrate_MB_model(model, [glacier], params)
     @test model.mass_balance isa Vector{<:TImodel1}
     @test length(model.mass_balance) == 1
     # get_mb_model should return the per-glacier model, matching the variable calibration
-    # (calibrate_MB_model! uses default variable prcp_fac, so compare against TI_var)
+    # (calibrate_MB_model uses default variable prcp_fac, so compare against TI_var)
     @test get_mb_model(model.mass_balance, 1).DDF ≈ TI_var.DDF
 
     # --- get_mb_model dispatch: single shared model vs per-glacier vector --------
@@ -89,12 +89,11 @@ function calibrate_ti_model_test()
     @test get_mb_model(single, 7) === single
     @test get_mb_model(model.mass_balance, 1) === model.mass_balance[1]
 
-    # --- calibrate_MB_model! is a no-op without a calibration routine ------------
+    # --- calibrate_MB_model is a no-op without a calibration routine ------------
     # TImodel2 has no calibration method, so the model is returned unchanged.
     ti2 = TImodel2(params)
     model2 = Sleipnir.Model(; iceflow = nothing, mass_balance = ti2)
-    calibrate_MB_model!(model2, [glacier], params)
-    @test model2.mass_balance === ti2              # left untouched (not vectorized)
+    @test calibrate_MB_model(model2, [glacier], params).mass_balance === ti2
 
     # --- calibration_period override --------------------------------------------
     TI_override = calibrate_ti_model(


### PR DESCRIPTION
`calibrate_MB_model!` can never mutate its `model` argument in place: for `TImodel1` it replaces a single model by one model per glacier, which changes the type of the `mass_balance` field, so it always returns a new `Model`. The `!` was misleading, and it caused real bugs — three separate call sites (this package's own `examples/calibrate_ti_hugonnet.jl`, ODINN's `Inversion` constructor, and its SMB calibration tutorial) discarded the return value and silently kept the uncalibrated model, which is what's chasing the CI failures on ODINN's `dev` right now.

Renamed to `calibrate_MB_model`, clean break with no deprecation shim. `examples/calibrate_ti_hugonnet.jl` gets the same one-line fix it was itself missing. Patch bump to 0.13.0 since this is breaking.

Downstream (Huginn, ODINN) already have companion branches ready, pending this release.